### PR TITLE
Fix empty matches being impossible at end of input

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -10,8 +10,8 @@ const execLambda = (pattern) => {
 
 const execString = (pattern) => {
   return (state) => {
-    const input = state.quasis[state.x];
-    if (input && state.y < input.length) {
+    if (state.x < state.quasis.length) {
+      const input = state.quasis[state.x];
       for (let i = 0, l = pattern.length; i < l; i++)
         if (input.charCodeAt(state.y + i) !== pattern.charCodeAt(i))
           return null;
@@ -26,10 +26,9 @@ const execRegex = (pattern) => {
     ? new RegExp(pattern.source, 'y')
     : new RegExp(pattern.source + '|()', 'g');
   return (state) => {
-    const input = state.quasis[state.x];
-    if (input && state.y < input.length) {
+    if (state.x < state.quasis.length) {
+      const input = state.quasis[state.x];
       pattern.lastIndex = state.y;
-
       let match;
       if (isStickySupported) {
         if (pattern.test(input))
@@ -59,8 +58,8 @@ export const interpolation = (predicate) => (state) => {
   let match;
 
   if (
-    state.y >= state.quasis[state.x].length &&
-    state.x < state.expressions.length
+    state.x < state.expressions.length &&
+    state.y >= state.quasis[state.x].length
   ) {
     state.y = 0;
     match = state.expressions[state.x++];

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -24,6 +24,11 @@ describe('required matcher', () => {
   `('should return $result when $input is passed', ({ input, result }) => {
     expectToParse(node, input, result);
   });
+
+  it('matches empty regex patterns', () => {
+    const node = match('node')`${/[ ]*/}`;
+    expectToParse(node, '', ['']);
+  });
 });
 
 describe('optional matcher', () => {


### PR DESCRIPTION
@fabiospampinato I think I discovered why regexes that can match empty strings sometimes don't catch at the end of inputs.

The check for the input string length aborts matching if it's at the end of the input, which isn't 100% correct, since a zero-width string / end-of-string index can still match against an optional-only regex.

Edit: Publishing this as another beta tag.